### PR TITLE
Fix Storage Chamber Automation

### DIFF
--- a/src/main/java/sonar/calculator/mod/common/tileentity/machines/TileEntityStorageChamber.java
+++ b/src/main/java/sonar/calculator/mod/common/tileentity/machines/TileEntityStorageChamber.java
@@ -27,7 +27,7 @@ public class TileEntityStorageChamber extends TileEntityLargeInventory implement
 		super.inv = new SonarLargeInventory(14, 1024) {
 			//needs fixing I think
 			public boolean isItemValidForPos(int slot, ItemStack item) {
-				if (item != null && item.getItemDamage() == slot) {
+				if (item != null && item.getMetadata() == slot) {
 					CircuitType stackType = getCircuitType(item);
 					if (stackType == null) {
 						return false;


### PR DESCRIPTION
In Minecraft + Forge 1.10 the item data for some items was moved into the NBT compound and the forge method getItemDamage was changed to point to this new location. The new method getMetadata has been added to access the meta value set directly on items.

I'm pretty sure this will work but I couldn't figure out how to configure a dev environment to build against the right version of SonarCore.